### PR TITLE
Support `.journal` files and additional comment chars

### DIFF
--- a/languages/ledger/config.toml
+++ b/languages/ledger/config.toml
@@ -1,4 +1,4 @@
 name = "Ledger"
 grammar = "ledger"
-path_suffixes = ["ledger", "ldg", "ldgr"]
+path_suffixes = ["journal", "ledger", "ldg", "ldgr"]
 line_comments = ["; "]

--- a/languages/ledger/config.toml
+++ b/languages/ledger/config.toml
@@ -1,4 +1,5 @@
 name = "Ledger"
 grammar = "ledger"
 path_suffixes = ["journal", "ledger", "ldg", "ldgr"]
-line_comments = ["; "]
+# See https://www.ledger-cli.org/3.0/doc/ledger3.html#Commenting-on-your-Journal
+line_comments = ["; ", "# ", "% ", "| ", "* "]

--- a/languages/ledger/injections.scm
+++ b/languages/ledger/injections.scm
@@ -1,2 +1,0 @@
-((comment) @injection.content
-  (#set! injection.language "comment"))


### PR DESCRIPTION
- adds support for `.journal` files, closing #1 
- removes `injections.scm` as – I believe – dead code
- support additional comment chars, as described in [the ledger docs](https://www.ledger-cli.org/3.0/doc/ledger3.html#Commenting-on-your-Journal)

Happy to make any updates you'd like. I removed `injections.scm` because I don't think it was doing anything, but if I'm wrong about that I'll be happy to revert that change.

`main` vs *this branch*  

<img width=400 src=https://github.com/user-attachments/assets/0d428be2-709e-4ce0-82e7-6b19103227b8>
<img width=400 src=https://github.com/user-attachments/assets/cb1e8a1f-06e1-46aa-a90a-848e86b4cc18>

