### PR TITLE
Improve highlighting

### DIFF
--- a/languages/ledger/highlights.scm
+++ b/languages/ledger/highlights.scm
@@ -1,6 +1,8 @@
 [
+  (block_comment)
   (comment)
   (note)
+  (test)
 ] @comment
 
 [
@@ -23,7 +25,15 @@
   (option_value)
 ] @string.special
 
+(payee) @property
 (account) @property
+(filename) @link_uri
+
+(code) @number
+(code
+    "(" @punctuation.bracket
+    ")" @punctuation.bracket
+)
 
 "include" @keyword.import
 
@@ -42,6 +52,7 @@
   "nomarket"
   "note"
   "payee"
+  "tag"
   "test"
   "A"
   "C"

--- a/languages/ledger/highlights.scm
+++ b/languages/ledger/highlights.scm
@@ -15,7 +15,7 @@
   (effective_date)
   (interval)
   (time)
-] @string
+] @string.special
 
 [
   (check_in)
@@ -23,7 +23,7 @@
   (commodity)
   (option)
   (option_value)
-] @string.special
+] @string.special.symbol
 
 (payee) @property
 (account) @property

--- a/languages/ledger/highlights.scm
+++ b/languages/ledger/highlights.scm
@@ -1,26 +1,26 @@
 [
-  (note)
   (comment)
+  (note)
 ] @comment
 
 [
-  (quantity)
   (negative_quantity)
+  (quantity)
 ] @number
 
 [
   (date)
   (effective_date)
-  (time)
   (interval)
+  (time)
 ] @string
 
 [
+  (check_in)
+  (check_out)
   (commodity)
   (option)
   (option_value)
-  (check_in)
-  (check_out)
 ] @string.special
 
 (account) @property
@@ -32,8 +32,8 @@
   "alias"
   "assert"
   "check"
-  "commodity"
   "comment"
+  "commodity"
   "def"
   "default"
   "end"
@@ -44,9 +44,9 @@
   "payee"
   "test"
   "A"
-  "Y"
-  "N"
-  "D"
   "C"
+  "D"
+  "N"
   "P"
+  "Y"
 ] @keyword

--- a/languages/ledger/outline.scm
+++ b/languages/ledger/outline.scm
@@ -1,0 +1,7 @@
+(xact
+    (plain_xact
+        (date) @context
+        (code)? @context
+        (payee) @name
+    )
+) @item


### PR DESCRIPTION
*This is stacked on – but not dependent on – #2; I'll rebase it if/when that is merged, or I can pull it out for merge independently.*

- sorts the various nodes and constants in the highlights file for easier maintenance
- adds more nodes and constants for highlighting
- changes the highlighting of some nodes (this is *subjective*)

Specifically, I feel like this improves the highlighting of commodity symbols and strings, payees and dates. 

*base branch* vs *this branch*

<img width=400 src=https://github.com/user-attachments/assets/abceb857-fb7c-4663-bb2c-9e9e816b0a23>
<img width=400 src=https://github.com/user-attachments/assets/7e58cc01-97a1-46d4-917c-733199a6bdab>

