### PR TITLE
deps: update tree-sitter-ledger

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/mrkstwrt/zed-ledger"
 
 [grammars.ledger]
 repository = "https://github.com/cbarrete/tree-sitter-ledger"
-commit = "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"
+commit = "96c92d4908a836bf8f661166721c98439f8afb80"
 
 [language_servers.ledger-language-server]
 name = "ledger-language-server"


### PR DESCRIPTION
Hi, this updates the tree-sitter-ledger to the current latest version. This includes quite a few changes (mostly fixes for edge cases that I happened to make use of 😆) from the previous pinned version. You can review them all at https://github.com/cbarrete/tree-sitter-ledger/compare/8a841fb20ce683bfbb3469e6ba67f2851cfdf94a...96c92d4908a836bf8f661166721c98439f8afb80

This is the last change that I have up my sleeve at this time. After this, I think that extension should be ready to tag a new release. Thank you!
