### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "ledger"
 name = "Ledger"
-version = "0.1.0"
+version = "0.2.0"
 schema_version = 1
 authors = ["Mark Stewart <me@markstewart.dev>"]
 description = "Support for ledger journal files"


### PR DESCRIPTION
This bumps the version of this extension to `0.2.0`, which is the only (if I understand correctly) thing left to do here before pushing a new release to https://github.com/zed-industries/extensions